### PR TITLE
Clearer MLOCK response - point to CS' MLOCK help.

### DIFF
--- a/src/messages.tab
+++ b/src/messages.tab
@@ -763,7 +763,7 @@ static  const char *  replies[] = {
 /* 739 */	NULL,
 /* 740 RPL_RSACHALLENGE2*/	":%s 740 %s :%s",
 /* 741 RPL_ENDOFRSACHALLENGE2*/	":%s 741 %s :End of CHALLENGE",
-/* 742 ERR_MLOCKRESTRICTED */	"%s %c %s :MODE cannot be set due to channel having an active MLOCK restriction policy",
+/* 742 ERR_MLOCKRESTRICTED */	"%s %c %s :MODE cannot be set as the channel has an active MLOCK restriction (see /msg chanserv help MLOCK)",
 /* 743 */	NULL,
 /* 744 */	NULL,
 /* 745 */	NULL,


### PR DESCRIPTION
I think it makes sense to give users a pointer on how to find out what MLOCK is
and how to change it.