### PR TITLE
Allow all opers to use DEHELPER

### DIFF
--- a/extensions/m_dehelper.c
+++ b/extensions/m_dehelper.c
@@ -57,6 +57,11 @@ static int m_dehelper(struct Client *client_p, struct Client *source_p, int parc
 {
 	struct Client *target_p;
 
+	if (!IsAnyOper(source_p))
+	{
+		sendto_one_numeric(source_p, ERR_NOPRIVILEGES, form_str(ERR_NOPRIVILEGES));
+		return 0;
+	}
 	if (!IsOperDehelper(source_p))
 	{
 		sendto_one(source_p, form_str(ERR_NOPRIVS), me.name, source_p->name, "dehelper");

--- a/extensions/m_dehelper.c
+++ b/extensions/m_dehelper.c
@@ -40,26 +40,26 @@
 
 #include <string.h>
 
-static int mo_dehelper(struct Client *, struct Client *, int, const char **);
+static int m_dehelper(struct Client *, struct Client *, int, const char **);
 static int me_dehelper(struct Client *, struct Client *, int, const char **);
 
 static int do_dehelper(struct Client *source_p, struct Client *target_p);
 
 struct Message dehelper_msgtab = {
 	"DEHELPER", 0, 0, 0, MFLG_SLOW,
-	{mg_unreg, mg_not_oper, mg_not_oper, mg_ignore, {me_dehelper, 2}, {mo_dehelper, 2}}
+	{mg_unreg, {m_dehelper, 2}, mg_not_oper, mg_ignore, {me_dehelper, 2}, {m_dehelper, 2}}
 };
 
 mapi_clist_av1 dehelper_clist[] = { &dehelper_msgtab, NULL };
 DECLARE_MODULE_AV1(dehelper, NULL, NULL, dehelper_clist, NULL, NULL, "$Revision: 254 $");
 
-static int mo_dehelper(struct Client *client_p, struct Client *source_p, int parc, const char **parv)
+static int m_dehelper(struct Client *client_p, struct Client *source_p, int parc, const char **parv)
 {
 	struct Client *target_p;
 
-	if (!IsOperAdmin(source_p))
+	if (!IsOperDehelper(source_p))
 	{
-		sendto_one(source_p, form_str(ERR_NOPRIVS), me.name, source_p->name, "admin");
+		sendto_one(source_p, form_str(ERR_NOPRIVS), me.name, source_p->name, "dehelper");
 		return 0;
 	}
 

--- a/include/s_newconf.h
+++ b/include/s_newconf.h
@@ -155,6 +155,7 @@ extern void cluster_generic(struct Client *, const char *, int cltype,
 #define HasPrivilege(x, y)	((x)->localClient != NULL && (x)->localClient->privset != NULL && privilegeset_in_set((x)->localClient->privset, (y)))
 
 #define IsOperHelper(x)         HasPrivilege(x, "oper:helpop")
+#define IsOperDehelper(x)       HasPrivilege(x, "oper:dehelper")
 #define IsOperOperwall(x)       HasPrivilege(x, "oper:operwall")
 #define IsOperStaffer(x)        HasPrivilege(x, "oper:staffer")
 #define IsOperKill(x)           HasPrivilege(x, "oper:kill")


### PR DESCRIPTION
Since freenode relies on /stats p a lot, having all opers able to use /dehelper will be easier to remove someone who fell asleep while +h