### PR TITLE
add @ prefix to op-moderated (+z) messages 

### DIFF
--- a/doc/example.conf
+++ b/doc/example.conf
@@ -343,6 +343,7 @@ channel {
 	resv_forcepart = yes;
 	channel_target_change = yes;
 	disable_local_channels = no;
+	opmod_send_cprivmsg = no;
 };
 
 serverhide {

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -777,6 +777,11 @@ channel {
 	 * supported.
 	 */
 	disable_local_channels = no;
+
+	/* opmod_send_cprivmsg: format messages sent to ops due to +z
+	 * as PRIVMSG @#channel when sent to clients.
+	 */
+	opmod_send_cprivmsg = no;
 };
 
 

--- a/include/s_conf.h
+++ b/include/s_conf.h
@@ -260,6 +260,7 @@ struct config_channel_entry
 	int only_ascii_channels;
 	int resv_forcepart;
 	int channel_target_change;
+	int opmod_send_cprivmsg;
 };
 
 struct config_server_hide

--- a/modules/m_info.c
+++ b/modules/m_info.c
@@ -639,6 +639,12 @@ static struct InfoStruct info_table[] = {
 		"Force-part local users on channel RESV"
 	},
 	{
+		"opmod_send_cprivmsg",
+		OUTPUT_BOOLEAN_YN,
+		&ConfigChannel.opmod_send_cprivmsg,
+		"Send messages to @#channel if affected by +z"
+	},
+	{
 		"disable_hidden",
 		OUTPUT_BOOLEAN_YN,
 		&ConfigServerHide.disable_hidden,

--- a/src/newconf.c
+++ b/src/newconf.c
@@ -2229,6 +2229,7 @@ static struct ConfEntry conf_channel_table[] =
 	{ "resv_forcepart",     CF_YESNO, NULL, 0, &ConfigChannel.resv_forcepart	},
 	{ "channel_target_change", CF_YESNO, NULL, 0, &ConfigChannel.channel_target_change	},
 	{ "disable_local_channels", CF_YESNO, NULL, 0, &ConfigChannel.disable_local_channels },
+	{ "opmod_send_cprivmsg", CF_YESNO, NULL, 0, &ConfigChannel.opmod_send_cprivmsg	},
 	{ "\0", 		0, 	  NULL, 0, NULL }
 };
 

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -775,6 +775,7 @@ set_default_conf(void)
 	ConfigChannel.resv_forcepart = YES;
 	ConfigChannel.channel_target_change = YES;
 	ConfigChannel.disable_local_channels = NO;
+	ConfigChannel.opmod_send_cprivmsg = NO;
 
 	ConfigServerHide.flatten_links = 0;
 	ConfigServerHide.links_delay = 300;

--- a/src/send.c
+++ b/src/send.c
@@ -555,36 +555,38 @@ sendto_channel_opmod(struct Client *one, struct Client *source_p,
 
 	current_serial++;
 
+	const char *cprivmsg_prefix = (ConfigChannel.opmod_send_cprivmsg ? "@" : "");
+
 	if(IsServer(source_p))
 	{
 		rb_linebuf_putmsg(&rb_linebuf_local, NULL, NULL,
-			       ":%s %s @%s :%s",
-			       source_p->name, command, chptr->chname, text);
+			       ":%s %s %s%s :%s",
+			       source_p->name, command, cprivmsg_prefix, chptr->chname, text);
 		rb_linebuf_putmsg(&rb_linebuf_local_id, NULL, NULL,
-			       ":%s %s @%s :%s",
-			       source_p->name, command, chptr->chname, text);
+			       ":%s %s %s%s :%s",
+			       source_p->name, command, cprivmsg_prefix, chptr->chname, text);
 	}
 	else
 	{
 		rb_linebuf_putmsg(&rb_linebuf_local, NULL, NULL,
-			       ":%s!%s@%s %s @%s :%s",
-			       source_p->name, source_p->username, 
-			       source_p->host, command, chptr->chname, text);
+			       ":%s!%s@%s %s %s%s :%s",
+			       source_p->name, source_p->username, source_p->host,
+			       command, cprivmsg_prefix, chptr->chname, text);
 		rb_linebuf_putmsg(&rb_linebuf_local_id, NULL, NULL,
-			       ":%s!%s@%s %s @%s :%c%s",
-			       source_p->name, source_p->username, 
-			       source_p->host, command, chptr->chname,
+			       ":%s!%s@%s %s %s%s :%c%s",
+			       source_p->name, source_p->username, source_p->host,
+			       command, cprivmsg_prefix, chptr->chname,
 			       IsIdentifiedMsg(source_p) ? '+' : '-', text);
 	}
 
 	if (chptr->mode.mode & MODE_MODERATED)
 		rb_linebuf_putmsg(&rb_linebuf_old, NULL, NULL,
-			       ":%s %s @%s :%s",
-			       use_id(source_p), command, chptr->chname, text);
+			       ":%s %s %s%s :%s",
+			       use_id(source_p), command, cprivmsg_prefix, chptr->chname, text);
 	else
 		rb_linebuf_putmsg(&rb_linebuf_old, NULL, NULL,
-			       ":%s NOTICE @%s :<%s:%s> %s",
-			       use_id(source_p->servptr), chptr->chname,
+			       ":%s NOTICE %s%s :<%s:%s> %s",
+			       use_id(source_p->servptr), cprivmsg_prefix, chptr->chname,
 			       source_p->name, chptr->chname, text);
 	rb_linebuf_putmsg(&rb_linebuf_new, NULL, NULL,
 		       ":%s %s =%s :%s",

--- a/src/send.c
+++ b/src/send.c
@@ -558,20 +558,20 @@ sendto_channel_opmod(struct Client *one, struct Client *source_p,
 	if(IsServer(source_p))
 	{
 		rb_linebuf_putmsg(&rb_linebuf_local, NULL, NULL,
-			       ":%s %s %s :%s",
+			       ":%s %s @%s :%s",
 			       source_p->name, command, chptr->chname, text);
 		rb_linebuf_putmsg(&rb_linebuf_local_id, NULL, NULL,
-			       ":%s %s %s :%s",
+			       ":%s %s @%s :%s",
 			       source_p->name, command, chptr->chname, text);
 	}
 	else
 	{
 		rb_linebuf_putmsg(&rb_linebuf_local, NULL, NULL,
-			       ":%s!%s@%s %s %s :%s",
+			       ":%s!%s@%s %s @%s :%s",
 			       source_p->name, source_p->username, 
 			       source_p->host, command, chptr->chname, text);
 		rb_linebuf_putmsg(&rb_linebuf_local_id, NULL, NULL,
-			       ":%s!%s@%s %s %s :%c%s",
+			       ":%s!%s@%s %s @%s :%c%s",
 			       source_p->name, source_p->username, 
 			       source_p->host, command, chptr->chname,
 			       IsIdentifiedMsg(source_p) ? '+' : '-', text);
@@ -579,7 +579,7 @@ sendto_channel_opmod(struct Client *one, struct Client *source_p,
 
 	if (chptr->mode.mode & MODE_MODERATED)
 		rb_linebuf_putmsg(&rb_linebuf_old, NULL, NULL,
-			       ":%s %s %s :%s",
+			       ":%s %s @%s :%s",
 			       use_id(source_p), command, chptr->chname, text);
 	else
 		rb_linebuf_putmsg(&rb_linebuf_old, NULL, NULL,


### PR DESCRIPTION
This change is a proposed solution to #30. It modifies op-moderated (+z) messages to distinguish them from regular channel traffic.

This is done by altering sendto_channel_opmod() to add an @ prefix, as with @#channel messages to all operators.