### PR TITLE
m_message: use same behaviour for +R users as +g users (closes #96)

### DIFF
--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -823,7 +823,9 @@ msg_client(enum message_type msgtype,
 		 * as a way to taunt users, e.g. harass them and hide behind +g
 		 * as a way of griefing.  --nenolod
 		 */
-		if(msgtype != MESSAGE_TYPE_NOTICE && IsSetCallerId(source_p) &&
+		if(msgtype != MESSAGE_TYPE_NOTICE &&
+				(IsSetCallerId(source_p) ||
+				 (IsSetRegOnlyMsg(source_p) && !target_p->user->suser[0])) &&
 				!accept_message(target_p, source_p) &&
 				!IsAnyOper(target_p))
 		{


### PR DESCRIPTION
This commit enables the same auto-accept behaviour for clients who are +R as exists for +g.