### PR TITLE
'help set mlock', not 'help mlock'

### DIFF
--- a/src/messages.tab
+++ b/src/messages.tab
@@ -763,7 +763,7 @@ static  const char *  replies[] = {
 /* 739 */	NULL,
 /* 740 RPL_RSACHALLENGE2*/	":%s 740 %s :%s",
 /* 741 RPL_ENDOFRSACHALLENGE2*/	":%s 741 %s :End of CHALLENGE",
-/* 742 ERR_MLOCKRESTRICTED */	"%s %c %s :MODE cannot be set as the channel has an active MLOCK restriction (see /msg chanserv help MLOCK)",
+/* 742 ERR_MLOCKRESTRICTED */	"%s %c %s :MODE cannot be set as the channel has an active MLOCK restriction (see /msg chanserv help set MLOCK)",
 /* 743 */	NULL,
 /* 744 */	NULL,
 /* 745 */	NULL,


### PR DESCRIPTION
I'm a pleb.

Sorry, all.