### PR TITLE
Remove general.kline_delay config option

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -1022,12 +1022,6 @@ general {
 	 */
 	dline_with_reason = yes;
 	
-	/* kline delay: delay the checking of klines until a specified time.
-	 * Useful if large kline lists are applied often to prevent the
-	 * server eating CPU.
-	 */
-	kline_delay = 0 seconds;
-
 	/* kline reason: show the user the reason why they are k/dlined 
 	 * on exit.  may give away who set k/dline when set via tcm.
 	 */

--- a/include/s_conf.h
+++ b/include/s_conf.h
@@ -178,7 +178,6 @@ struct config_file_entry
 	int ts_warn_delta;
 	int dline_with_reason;
 	int kline_with_reason;
-	int kline_delay;
 	int warn_no_nline;
 	int nick_delay;
 	int non_redundant_klines;

--- a/modules/m_info.c
+++ b/modules/m_info.c
@@ -303,12 +303,6 @@ static struct InfoStruct info_table[] = {
 		"Server is a hub"
 	},
 	{
-		"kline_delay",
-		OUTPUT_DECIMAL,
-		&ConfigFileEntry.kline_delay,
-		"Duration of time to delay kline checking"
-	},
-	{
 		"kline_reason",
 		OUTPUT_STRING,
 		&ConfigFileEntry.kline_reason,

--- a/src/newconf.c
+++ b/src/newconf.c
@@ -1515,15 +1515,6 @@ conf_set_general_hide_error_messages(void *data)
 }
 
 static void
-conf_set_general_kline_delay(void *data)
-{
-	ConfigFileEntry.kline_delay = *(unsigned int *) data;
-
-	/* THIS MUST BE HERE to stop us being unable to check klines */
-	kline_queued = 0;
-}
-
-static void
 conf_set_general_stats_k_oper_only(void *data)
 {
 	char *val = data;
@@ -2129,7 +2120,6 @@ static struct ConfEntry conf_general_table[] =
 	{ "compression_level", 	CF_INT,    conf_set_general_compression_level,	0, NULL },
 	{ "havent_read_conf", 	CF_YESNO,  conf_set_general_havent_read_conf,	0, NULL },
 	{ "hide_error_messages",CF_STRING, conf_set_general_hide_error_messages,0, NULL },
-	{ "kline_delay", 	CF_TIME,   conf_set_general_kline_delay,	0, NULL },
 	{ "stats_k_oper_only", 	CF_STRING, conf_set_general_stats_k_oper_only,	0, NULL },
 	{ "stats_i_oper_only", 	CF_STRING, conf_set_general_stats_i_oper_only,	0, NULL },
 	{ "default_umodes",	CF_QSTRING, conf_set_general_default_umodes, 0, NULL },

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -707,7 +707,6 @@ set_default_conf(void)
 	ConfigFileEntry.client_exit = YES;
 	ConfigFileEntry.dline_with_reason = YES;
 	ConfigFileEntry.kline_with_reason = YES;
-	ConfigFileEntry.kline_delay = 0;
 	ConfigFileEntry.warn_no_nline = YES;
 	ConfigFileEntry.non_redundant_klines = YES;
 	ConfigFileEntry.stats_e_disabled = NO;


### PR DESCRIPTION
It's no longer used for anything, since we check only one K-line when
adding new ones, and delaying that wouldn't make any sense.