### PR TITLE
m_ison: Do not report unregistered connections

### DIFF
--- a/modules/m_ison.c
+++ b/modules/m_ison.c
@@ -88,7 +88,7 @@ m_ison(struct Client *client_p, struct Client *source_p, int parc, const char *p
 		char *cs = LOCAL_COPY(parv[i]);
 		for (nick = rb_strtok_r(cs, " ", &p); nick; nick = rb_strtok_r(NULL, " ", &p))
 		{
-			target_p = find_named_client(nick);
+			target_p = find_named_person(nick);
 
 			if(target_p != NULL)
 			{


### PR DESCRIPTION
Prior to this, m_ison would report a nick as being online if a client that was not yet registered had chosen this nickname on the same server. This change adds a check to make sure the `struct Client` has a `struct User` associated with it, i.e. registration has occurred.

A bit of local testing with a single ircd says it works as intended, but I haven't been able to test it with multiple servers yet.