### PR TITLE
m_resv: Fix number of minutes in snote

### DIFF
--- a/modules/m_resv.c
+++ b/modules/m_resv.c
@@ -133,7 +133,7 @@ mo_resv(struct Client *client_p, struct Client *source_p, int parc, const char *
 	{
 		if (temp_time)
 			sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s is adding a %d min. RESV for [%s] on %s [%s]",
-					get_oper_name(source_p), temp_time, name, target_server, reason);
+					get_oper_name(source_p), temp_time / 60, name, target_server, reason);
 		else
 			sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s is adding a permanent RESV for [%s] on %s [%s]",
 					get_oper_name(source_p), name, target_server, reason);


### PR DESCRIPTION
For remote resvs, m_resv reported the duration as seconds in the snote. However, the format claimed minutes - this is incorrect. This commit converts the duration to minutes, which is consistent with the other
resv snotes.