### PR TITLE
Improve WEBIRC's TLS handling

### DIFF
--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -126,9 +126,9 @@ mr_webirc(struct Client *client_p, struct Client *source_p, int parc, const char
 	if (parc >= 6)
 	{
 		char *s;
-		for (s = strtok(parv[5], " "); s != NULL; s = strtok(NULL, " "))
+		for (s = parv[5]; s != NULL; (s = strchr(s, ' ')) && s++)
 		{
-			if (!ircncmp(s, "secure", 6) && (s[6] == '=' || s[6] == '\0'))
+			if (!ircncmp(s, "secure", 6) && (s[6] == '=' || s[6] == ' ' || s[6] == '\0'))
 				secure = 1;
 		}
 	}

--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -102,6 +102,11 @@ mr_webirc(struct Client *client_p, struct Client *source_p, int parc, const char
 		sendto_one(source_p, "NOTICE * :CGI:IRC auth blocks must have a password");
 		return 0;
 	}
+	if (!IsSSL(source_p) && aconf->flags & CONF_FLAGS_NEED_SSL)
+	{
+		sendto_one(source_p, "NOTICE * :Your CGI:IRC block requires SSL");
+		return 0;
+	}
 
 	if (EmptyString(parv[1]))
 		encr = "";

--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -136,7 +136,7 @@ mr_webirc(struct Client *client_p, struct Client *source_p, int parc, const char
 	if (secure && !IsSSL(source_p))
 	{
 		sendto_one(source_p, "NOTICE * :CGI:IRC is not connected securely; marking you as insecure");
-		return 0;
+		secure = 0;
 	}
 
 	if (!secure)

--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -78,6 +78,8 @@ mr_webirc(struct Client *client_p, struct Client *source_p, int parc, const char
 	struct ConfItem *aconf;
 	const char *encr;
 
+	int secure = 0;
+
 	if (!strchr(parv[4], '.') && !strchr(parv[4], ':'))
 	{
 		sendto_one(source_p, "NOTICE * :Invalid IP");
@@ -121,6 +123,26 @@ mr_webirc(struct Client *client_p, struct Client *source_p, int parc, const char
 		return 0;
 	}
 
+	if (parc >= 6)
+	{
+		char *s;
+		for (s = strtok(parv[5], " "); s != NULL; s = strtok(NULL, " "))
+		{
+			if (!ircncmp(s, "secure", 6) && (s[6] == '=' || s[6] == '\0'))
+				secure = 1;
+		}
+	}
+
+	if (secure && !IsSSL(source_p))
+	{
+		sendto_one(source_p, "NOTICE * :CGI:IRC is not connected securely; marking you as insecure");
+		return 0;
+	}
+
+	if (!secure)
+	{
+		SetInsecure(source_p);
+	}
 
 	rb_strlcpy(source_p->sockhost, parv[4], sizeof(source_p->sockhost));
 

--- a/include/client.h
+++ b/include/client.h
@@ -409,6 +409,7 @@ struct ListClient
 #define LFLAGS_SSL		0x00000001
 #define LFLAGS_FLUSH		0x00000002
 #define LFLAGS_CORK		0x00000004
+#define LFLAGS_INSECURE	0x00000008	/* for marking SSL clients as insecure before registration */
 
 /* umodes, settable flags */
 /* lots of this moved to snomask -- jilles */
@@ -523,6 +524,10 @@ struct ListClient
 #define IsFlush(x)		((x)->localClient->localflags & LFLAGS_FLUSH)
 #define SetFlush(x)		((x)->localClient->localflags |= LFLAGS_FLUSH)
 #define ClearFlush(x)		((x)->localClient->localflags &= ~LFLAGS_FLUSH)
+
+#define IsInsecure(x)		((x)->localClient->localflags & LFLAGS_INSECURE)
+#define SetInsecure(x)		((x)->localClient->localflags |= LFLAGS_INSECURE)
+#define ClearInsecure(x)		((x)->localClient->localflags &= ~LFLAGS_INSECURE)
 
 /* oper flags */
 #define MyOper(x)               (MyConnect(x) && IsOper(x))

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -531,7 +531,7 @@ register_local_user(struct Client *client_p, struct Client *source_p, const char
 		add_to_id_hash(source_p->id, source_p);
 	}
 
-	if (IsSSL(source_p))
+	if (IsSSL(source_p) && !IsInsecure(source_p))
 		source_p->umodes |= UMODE_SSLCLIENT;
 
 	if (source_p->umodes & UMODE_INVISIBLE)


### PR DESCRIPTION
Enforce `need_ssl` on webirc blocks, and don't set +Z on webirc users unless the `WEBIRC` command specifies the `secure` option