### PR TITLE
Make clang 8 happy on FreeBSD

### DIFF
--- a/modules/m_cmessage.c
+++ b/modules/m_cmessage.c
@@ -196,11 +196,11 @@ m_cmessage(int p_or_n, enum message_type msgtype,
 	call_hook(h_privmsg_user, &hdata);
 
 	if (hdata.approved != 0)
-		return;
+		return 0;
 
 	/* the hook may have killed them */
 	if (IsAnyDead(source_p))
-		return;
+		return 0;
 
 	sendto_anywhere_message(target_p, source_p, cmdname[msgtype], "%s", hdata.text);
 

--- a/modules/m_sasl.c
+++ b/modules/m_sasl.c
@@ -86,7 +86,7 @@ mr_authenticate(struct Client *client_p, struct Client *source_p,
 	if (*parv[1] == ':' || strchr(parv[1], ' '))
 	{
 		exit_client(client_p, client_p, client_p, "Malformed AUTHENTICATE");
-		return;
+		return 0;
 	}
 
 	if(source_p->preClient->sasl_complete)


### PR DESCRIPTION
Fixes:

m_cmessage.c:199:3: error: non-void function 'm_cmessage' should return a value [-Wreturn-type]
m_cmessage.c:203:3: error: non-void function 'm_cmessage' should return a value [-Wreturn-type]
m_sasl.c:89:3: error: non-void function 'mr_authenticate' should return a value [-Wreturn-type]

